### PR TITLE
Update ArrayClass.php to not pass variable by reference.

### DIFF
--- a/src/O/ArrayClass.php
+++ b/src/O/ArrayClass.php
@@ -78,7 +78,8 @@ class ArrayClass implements \IteratorAggregate, \ArrayAccess {
   }
 
   function map($callback) {
-    $params = a(func_get_args())->slice(1);
+    $args = func_get_args();
+    $params = a($args)->slice(1);
     a($params)->unshift($callback, $this->a);
     return call_user_func_array("array_map", $params);
   }


### PR DESCRIPTION
For PHP 5.4 compatibility, variables cannot be passed by reference.
